### PR TITLE
Make Anaconda installation script executable

### DIFF
--- a/_posts/2022-08-15-TT100-tools.md
+++ b/_posts/2022-08-15-TT100-tools.md
@@ -82,8 +82,9 @@ $ brew install java # openjdk install
 - Only if there is a wget error... To find the latest Linux-x86 distribution scroll to the bottom of this page: https://www.anaconda.com/products/distribution.  Change wget and Anaconda3 command based on new link.
 ```bash
 > PS C:\Users\UserName> wsl  # Windows prompt to WSL command
-$ cd ~
+$ cd /tmp
 $ wget https://repo.anaconda.com/archive/Anaconda3-2022.05-Linux-x86_64.sh
+$ chmod +x Anaconda3-2022.05-Linux-x86_64.sh
 # Answer yes to all the prompts
 $ ./Anaconda3-2022.05-Linux-x86_64.sh
 ```


### PR DESCRIPTION
When the Anaconda script first downloads, it does not have executable permissions. This PR adds a line that instructs the student to give the script executable permission via `chmod`.