### PR TITLE
minor update to flask deployment guide

### DIFF
--- a/_posts/2022-09-26-PBL-deploy.md
+++ b/_posts/2022-09-26-PBL-deploy.md
@@ -336,9 +336,9 @@ server {
 
 ### Activating Nginx configuration
 * Activate/enabled Nginx server configuration:
-  * nginx configuration file: test
+  * nginx configuration file can be called what you want it to be.
 ```bash
-$ sudo ln -s /etc/nginx/sites-available/test /etc/nginx/sites-enabled
+$ sudo ln -s /etc/nginx/sites-available/[your config file] /etc/nginx/sites-enabled[your config file]
 $ sudo nginx -t
 ```
 


### PR DESCRIPTION
I recently was helping my sisters group's devops person, and they were having trouble with this guide, because the ln command was incorrect. As is, it creates a dead symlink.